### PR TITLE
chore(release): add Build & Tooling category and create the missing release-note labels

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,3 +1,13 @@
+# Configuration for GitHub's auto-generated release notes.
+#
+# GitHub categorises entries by the PULL REQUEST'S LABELS only — it does not
+# read commit messages or PR titles. An unlabelled PR falls through to the "*"
+# catch-all at the bottom, which is how the v2.12.1 security and dependency
+# work ended up filed under "Other Changes". Label PRs before merging, or the
+# categories below do nothing.
+#
+# Every label named here exists in the repo; keep it that way when adding more.
+
 changelog:
   categories:
     - title: 🚀 New Features
@@ -32,6 +42,11 @@ changelog:
         - maintenance
         - refactor
         - chore
+    - title: 🏗️ Build & Tooling
+      labels:
+        - build
+        - ci
+        - tooling
     - title: 🔒 Security
       labels:
         - security


### PR DESCRIPTION
Follow-up to #81, where a security and dependency release was filed under "🔄 Other Changes".

## The actual cause

Not a missing category — 🔒 Security and 📦 Dependencies were already configured. GitHub's
generated release notes categorise by the **pull request's labels only**; they never look at commit
messages or PR titles. PR #81 carried no labels, so it fell through the `"*"` catch-all.

Worse, **21 of the labels this config referenced had never been created in the repo** — including
`security`, `maintenance`, `parser`, `ui`, `docs`, `test` and `deps`. Most categories here could
therefore never match anything, and the failure is silent: notes still generate, just in the wrong
bucket.

All 21 now exist, plus `build` / `ci` / `tooling` for the new category (created directly, no code
change needed). A header comment on the file records that labels are the mechanism, so the next
person does not re-diagnose this.

## New category

🏗️ **Build & Tooling** — edition migrations, toolchain moves, and release-workflow changes.
Previously these had to be filed under Maintenance or fall through to Other. v2.12.1 alone had a
Rust edition 2024 migration and four GitHub Actions major bumps with nowhere to go.

## Verified

`release.yml` parses cleanly (12 categories), and every label referenced by the config — including
the two `exclude` entries — now resolves to a real label in the repo.

PR #81 has been labelled retroactively (`security`, `dependencies`, `bug`, `build`) so the
historical record and the `v2.12.0...v2.12.1` compare view are correct.
